### PR TITLE
Remove duplicate skill ids when showing skill list (in case of duplic…

### DIFF
--- a/lib/bestiary.rb
+++ b/lib/bestiary.rb
@@ -970,6 +970,7 @@ class Bestiary < Window_Book
           v.include?(@id)
         end.keys
       else skills = @enemy.enemy.actions.collect {|a| a.skill_id } end
+      skills = skills.uniq # remove duplicate skill ids for duplicate actions
       skills.each do |id|
         next if @enemy.enemy.hidden_skills.include?(id)
         if RequireSkillKnown


### PR DESCRIPTION
…ate defined actions)

Just a simple commit that removes duplicates in case there are several defined actions using the same skill. You wouldn't want those to display twice in the skill list as it'd be confusing for the player.
